### PR TITLE
Added support to run Gluster commands over SSH

### DIFF
--- a/gluster/cli/__init__.py
+++ b/gluster/cli/__init__.py
@@ -9,7 +9,7 @@
 #  cases as published by the Free Software Foundation.
 #
 
-__version__ = '0.3'
+__version__ = '0.4'
 
 from . import volume
 from . import bitrot
@@ -25,6 +25,9 @@ from . import tier
 
 from .utils import (set_gluster_path,
                     set_gluster_socket,
+                    set_ssh_host,
+                    set_ssh_pem_file,
+                    ssh_connection,
                     GlusterCmdException)
 
 # Reexport
@@ -41,4 +44,7 @@ __all__ = ["volume",
            "tier",
            "set_gluster_path",
            "set_gluster_socket",
+           "set_ssh_host",
+           "set_ssh_pem_file",
+           "ssh_connection",
            "GlusterCmdException"]


### PR DESCRIPTION
If ssh host and pem key details are set, it runs gluster commands
over ssh, else runs in local node.

Example,

    from gluster.cli import volume, set_ssh_pem_file, set_ssh_host

    set_ssh_pem_file("/home/aravinda/glustercli.pem")
    set_ssh_host("remotenode1")

    print volume.info()

Above code prints Gluster Volume info from `remotenode1`

Alternatively, context manager can be used as below,

    from gluster.cli import volume, ssh_connection

    with ssh_connection("remotenode1", "/home/aravinda/glustercli.pem"):
        print volume.info()
        print volume.status_detail()

Note:
- SSH connection is not persistent, each command run is independent
  ssh command.
- Changing ssh_host/pem path is not yet Thread safe.
- SSH support depends on paramiko library, which is not added in dependency
   list since not required if installed in storage node. Required only for this usecase.

Signed-off-by: Aravinda VK <mail@aravindavk.in>