### PR TITLE
New Feature: Subvolume grouping for Volume info and Volume Status

### DIFF
--- a/docs/volume.md
+++ b/docs/volume.md
@@ -85,24 +85,26 @@ Create Gluster Volume
 
 ## info
 ```python
-info(volname=None)
+info(volname=None, group_subvols=False)
 ```
 
 Get Gluster Volume Info
 
 :param volname: Volume Name
+:param group_subvols: Show Subvolume Information in Groups
 :returns: Returns Volume Info, raises
  GlusterCmdException((rc, out, err)) on error
 
 
 ## status_detail
 ```python
-status_detail(volname=None)
+status_detail(volname=None, group_subvols=False)
 ```
 
 Get Gluster Volume Status
 
 :param volname: Volume Name
+:param group_subvols: Show Subvolume Information in Groups
 :returns: Returns Volume Status, raises
  GlusterCmdException((rc, out, err)) on error
 

--- a/glustercli/cli/volume.py
+++ b/glustercli/cli/volume.py
@@ -136,11 +136,12 @@ def create(volname, volbricks, replica=0, stripe=0, arbiter=0, disperse=0,
     return volume_execute(cmd)
 
 
-def info(volname=None):
+def info(volname=None, group_subvols=False):
     """
     Get Gluster Volume Info
 
     :param volname: Volume Name
+    :param group_subvols: Show Subvolume Information in Groups
     :returns: Returns Volume Info, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -148,14 +149,16 @@ def info(volname=None):
     if volname is not None:
         cmd += [volname]
 
-    return parse_volume_info(volume_execute_xml(cmd))
+    return parse_volume_info(volume_execute_xml(cmd),
+                             group_subvols=group_subvols)
 
 
-def status_detail(volname=None):
+def status_detail(volname=None, group_subvols=False):
     """
     Get Gluster Volume Status
 
     :param volname: Volume Name
+    :param group_subvols: Show Subvolume Information in Groups
     :returns: Returns Volume Status, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -165,7 +168,9 @@ def status_detail(volname=None):
     else:
         cmd += ["all", "detail"]
 
-    return parse_volume_status(volume_execute_xml(cmd), info(volname))
+    return parse_volume_status(volume_execute_xml(cmd),
+                               info(volname),
+                               group_subvols=group_subvols)
 
 
 def optset(volname, opts):


### PR DESCRIPTION
New argument added to `volume.info` and `volume.status_detail` functions
to group the bricks into sub volumes.

For example, `volume.info(group_subvols=True)` or
`volume.status_detail(group_subvols=True)`

This enhancement is very useful to make decisions like a subvol
is down or not, utilization of a subvol etc.

This change is backward compatible since the default value of
`group_subvols` is False.

With `group_subvols=False`

```
{
  "name": "gv1",
  "replica": 3,
  "type": "DISTRIBUTED_REPLICATE",
  "bricks": [
    {BRICK1}, {BRICK2}, {BRICK3}, {BRICK4}, {BRICK5}, {BRICK6}
  ]
}
```

With `group_subvols=True`

```
{
  "name": "gv1",
  "replica": 3,
  "type": "DISTRIBUTED_REPLICATE",
  "subvols": [
    {
       "name": "gv1-replicate-0",
       "type": "REPLICATE",
       "bricks": [
         {BRICK1}, {BRICK2}, {BRICK3}
       ]
    },
    {
       "name": "gv1-replicate-1",
       "type": "REPLICATE",
       "bricks": [
         {BRICK4}, {BRICK5}, {BRICK6}
       ]
    }
  ]
}
```

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>