### PR TITLE
Fix Volume size calculation

### DIFF
--- a/glustercli/cli/parsers.py
+++ b/glustercli/cli/parsers.py
@@ -95,14 +95,16 @@ def _update_volume_utilization(volumes):
                         effective_capacity_used = brick["size_used"]
 
                     if effective_capacity_total == 0 or \
-                      brick["size_total"] <= effective_capacity_total:
+                      (brick["size_total"] <= effective_capacity_total and
+                       brick["size_total"] > 0):
                         effective_capacity_total = brick["size_total"]
 
                     if brick["inodes_used"] >= effective_inodes_used:
                         effective_inodes_used = brick["inodes_used"]
 
                     if effective_inodes_total == 0 or \
-                      brick["inodes_total"] <= effective_inodes_total:
+                      (brick["inodes_total"] <= effective_inodes_total and
+                       brick["inodes_total"] > 0):
                         effective_inodes_total = brick["inodes_total"]
 
             if subvol["type"] == TYPE_DISPERSE:


### PR DESCRIPTION
If Last brick in a subvolume was down then it resets the
subvol size to zero. This patch fixes the issue by checking the
size > 0.

Signed-off-by: Aravinda Vishwanathapura <aravinda@kadalu.io>