### PR TITLE
fix brick removal functions

### DIFF
--- a/glustercli/cli/bricks.py
+++ b/glustercli/cli/bricks.py
@@ -43,7 +43,7 @@ def remove_force(volname, bricks, replica=None):
     :param volname: Volume Name
     :param bricks: List of Bricks
     :param replica: Replica Count
-    :returns: Output of remove-brick start command, raises
+    :returns: Output of remove-brick force command, raises
      GlusterCmdException((rc, out, err)) on error
     """
     cmd = ["remove-brick", volname]

--- a/glustercli/cli/bricks.py
+++ b/glustercli/cli/bricks.py
@@ -36,14 +36,33 @@ def add(volname, bricks, stripe=None, replica=None,
     return volume_execute(cmd)
 
 
-def remove_start(volname, bricks, replica=None, force=False):
+def remove_force(volname, bricks, replica=None):
+    """
+    Remove Bricks force
+
+    :param volname: Volume Name
+    :param bricks: List of Bricks
+    :param replica: Replica Count
+    :returns: Output of remove-brick start command, raises
+     GlusterCmdException((rc, out, err)) on error
+    """
+    cmd = ["remove-brick", volname]
+    if replica is not None:
+        cmd += ["replica", "{0}".format(replica)]
+
+    cmd += bricks
+    cmd += ["force"]
+
+    return volume_execute(cmd)
+
+
+def remove_start(volname, bricks, replica=None):
     """
     Remove Bricks start
 
     :param volname: Volume Name
     :param bricks: List of Bricks
     :param replica: Replica Count
-    :param force: True|False Force Remove Bricks
     :returns: Output of remove-brick start command, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -53,20 +72,17 @@ def remove_start(volname, bricks, replica=None, force=False):
 
     cmd += bricks
     cmd += ["start"]
-    if force:
-        cmd += ["force"]
 
     return volume_execute(cmd)
 
 
-def remove_stop(volname, bricks, replica=None, force=False):
+def remove_stop(volname, bricks, replica=None):
     """
     Remove Bricks stop
 
     :param volname: Volume Name
     :param bricks: List of Bricks
     :param replica: Replica Count
-    :param force: True|False Force Remove Bricks
     :returns: Output of remove-brick stop command, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -76,20 +92,17 @@ def remove_stop(volname, bricks, replica=None, force=False):
 
     cmd += bricks
     cmd += ["stop"]
-    if force:
-        cmd += ["force"]
 
     return volume_execute(cmd)
 
 
-def remove_commit(volname, bricks, replica=None, force=False):
+def remove_commit(volname, bricks, replica=None):
     """
     Remove Bricks Commit
 
     :param volname: Volume Name
     :param bricks: List of Bricks
     :param replica: Replica Count
-    :param force: True|False Force Remove Bricks
     :returns: Output of remove-brick commit command, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -99,20 +112,17 @@ def remove_commit(volname, bricks, replica=None, force=False):
 
     cmd += bricks
     cmd += ["commit"]
-    if force:
-        cmd += ["force"]
 
     return volume_execute(cmd)
 
 
-def remove_status(volname, bricks, replica=None, force=False):
+def remove_status(volname, bricks, replica=None):
     """
     Remove Bricks status
 
     :param volname: Volume Name
     :param bricks: List of Bricks
     :param replica: Replica Count
-    :param force: True|False Force Remove Bricks
     :returns: Remove Bricks Status, raises
      GlusterCmdException((rc, out, err)) on error
     """
@@ -122,24 +132,26 @@ def remove_status(volname, bricks, replica=None, force=False):
 
     cmd += bricks
     cmd += ["status"]
-    if force:
-        cmd += ["force"]
 
     return parse_remove_brick_status(volume_execute_xml(cmd))
 
 
-def replace_commit(volname, source_brick, new_brick, force=False):
+def replace_commit(volname, source_brick, new_brick):
     """
     Replace Bricks
 
     :param volname: Volume Name
     :param source_brick: Source Brick
     :param new_brick: New Replacement Brick
-    :param force: True|False Force Replace Bricks
     :returns: Output of replace-brick command, raises
      GlusterCmdException((rc, out, err)) on error
     """
-    cmd = ["replace-brick", volname, source_brick, new_brick, "commit"]
-    if force:
-        cmd += ["force"]
+    cmd = [
+        "replace-brick",
+        volname,
+        source_brick,
+        new_brick,
+        "commit", "force"
+    ]
+
     return volume_execute(cmd)


### PR DESCRIPTION
I'm not sure if a past version of gluster allowed you to add a `force` keyword to the CLI to forcefully run the given operation, but version 9.0 doesn't allow this.

- added `remove_force` method to mirror the same style of other methods wrt to brick removal procedures
- removed the `force` kwarg from the other `remove_*` methods.
- `replace-brick` CLI command only accepts `commit force` in the arguments