### PR TITLE
fix execute_or_raise method

### DIFF
--- a/glustercli/cli/utils.py
+++ b/glustercli/cli/utils.py
@@ -116,10 +116,10 @@ def check_for_xml_errors(data):
     if error is not None:
         try:
             error = ET.fromstring(error)
-        except Exception:
+        except ET.ParseError:
             # means parsing xml data failed
             # so play it safe and ignore
-            pass
+            return
 
         op_ret = error.find('opRet').text or None
         op_err = error.find('opErrstr').text or None

--- a/glustercli/cli/utils.py
+++ b/glustercli/cli/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import subprocess
+import xml.etree.cElementTree as ET
 from contextlib import contextmanager
 
 GLUSTERCMD = "gluster"
@@ -96,10 +97,45 @@ def set_gluster_socket(path):
     GLUSTERD_SOCKET = path
 
 
+def check_for_xml_errors(data):
+    stdout = data[0]
+    stderr = data[1]
+
+    # depending on the gluster sub-command that's run
+    # it can have a returncode of 0 (meaning success)
+    # however this could mean that the formatting of
+    # the xml was successful and not the command that
+    # was run. We need to check stdout and/or stderr
+    # for the `opRet` xml element and if it's -1, then
+    # format the error accordingly and raise
+    # GlusterCmdException
+
+    # for reasons unknown, some commands will fail and
+    # return to stdout instead of stderr and vice versa
+    error = stdout if stdout else stderr or None
+    if error is not None:
+        try:
+            error = ET.fromstring(error)
+            op_ret = error.find('opRet').text or None
+            op_err = error.find('opErrstr').text or None
+            if op_ret == '-1':
+                if op_err is None:
+                    # means command failed but no error
+                    # string so make up one
+                    op_err = 'FAILED'
+                return GlusterCmdException((int(op_ret), '', op_err))
+        except Exception:
+            pass
+
+
 def execute_or_raise(cmd):
     returncode, out, err = execute(cmd)
     if returncode != 0:
         raise GlusterCmdException((returncode, out, err))
+
+    exception = check_for_xml_errors((out, err))
+    if isinstance(exception, GlusterCmdException):
+        raise exception
 
     return out.strip()
 


### PR DESCRIPTION
Testing the `removebrick` method, I've found that if you issue a `STATUS` operation (without first calling `START`), a traceback can be raise like below:
`  File "/usr/lib/python3/dist-packages/glustercli/cli/bricks.py", line 128, in remove_status
    return parse_remove_brick_status(volume_execute_xml(cmd))
  File "/usr/lib/python3/dist-packages/glustercli/cli/parsers.py", line 602, in parse_remove_brick_status
    result = {'nodes': [], 'aggregate': _parse_remove_aggregate(
  File "/usr/lib/python3/dist-packages/glustercli/cli/parsers.py", line 630, in _parse_remove_aggregate
    'files': aggregate_el.find('files').text,
AttributeError: 'NoneType' object has no attribute 'find'`

This is because the returncode of the command is `0` which represents success. Looking at source code for the gluster cli program, it seems as though the command is supposed to return success as long as the formatting of the xml data is successful. Instead it returns formatted xml code that has `opRet` element set to `-1` representing the command failed and `opErrstr` with the underlying error. I've added a new method that `execute_or_raise` calls that will check to see if the command returns an xml error.