### PR TITLE
brick_status_data.get() could fail if the variable is None

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
-glustercli (0.7-1) experimental; urgency=medium
+glustercli (0.8) unstable; urgency=medium
 
   [ Caleb St. John ]
   * initial debian package
 
- -- Caleb <yocalebo@gmail.com>  Sat, 09 May 2020 08:47:46 -0400
+ -- Caleb <yocalebo@gmail.com>  Wed, 05 May 2021 15:10:00 -0400

--- a/glustercli/cli/parsers.py
+++ b/glustercli/cli/parsers.py
@@ -298,8 +298,13 @@ def parse_volume_status(status_data, volinfo, group_subvols=False):
 
         for brick in vol["bricks"]:
             brick_status_data = tmp_brick_status.get(brick["name"], None)
-            brick_online = brick_status_data.get("online", False)
-            if brick_status_data is None or not brick_online:
+            if brick_status_data is None:
+                use_default = True
+            else:
+                # brick could be offline
+                use_default = not brick_status_data.get("online", False)
+
+            if use_default:
                 # Default Status
                 volumes[-1]["bricks"].append({
                     "name": brick["name"],


### PR DESCRIPTION
```
  File "/usr/lib/python3/dist-packages/glustercli/cli/volume.py", line 187, in status_detail
    return parse_volume_status(volume_execute_xml(cmd),
  File "/usr/lib/python3/dist-packages/glustercli/cli/parsers.py", line 301, in parse_volume_status
    brick_online = brick_status_data.get("online", False)
AttributeError: 'NoneType' object has no attribute 'get'
```

- also update `debian/changelog` to match the github release