### PR TITLE
Replace VERSION variable with setuptools_scm for versioning

### DIFF
--- a/.github/workflows/on-release-tag.yml
+++ b/.github/workflows/on-release-tag.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install setuptools setuptools_scm wheel twine
       - name: Publish to Pypi
         run: |
-          rm -rf dist; VERSION=${{ env.glustercli_version }} python3 setup.py sdist bdist_wheel;
+          rm -rf dist; python3 setup.py sdist bdist_wheel;
           TWINE_PASSWORD=${{ secrets.TWINE_PASSWORD }} twine upload --username aravindavk dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ pycscope.*
 build
 dist
 docs/_build
+glustercli/_version.py
 .DS_Store
 _build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "glustercli/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,16 @@
 import os
 import re
 from setuptools import setup
+from importlib.metadata import version, PackageNotFoundError
 
-VERSION = os.environ.get("VERSION", "master")
-
+try:
+    __version__ = version('glustercli')
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 setup(
     name='glustercli',
-    version=VERSION,
+    version=__version__,
     description='Python bindings for GlusterFS CLI and Metrics collection',
     license='GPLv2 or LGPLv3+',
     author='Aravinda Vishwanathapura',


### PR DESCRIPTION
Instead of using a custom environment variable for setting the version, I propose to use [setuptools_scm](https://github.com/pypa/setuptools_scm) which does the same thing based on repository tag.

Doing so, a call to `python setup.py sdist bdist_wheel` outside of CI would give the same result, without the need to supply VERSION env manually.

Here is an example :

**With current method**
```bash
$ VERSION=0.8.3 python setup.py sdist bdist_wheel

[ ... ]

$ cd dist && tar -xzf glustercli-0.8.3.tar.gz && cd glustercli-0.8.3 && python setup.py install
UserWarning: The version specified ('master') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
running egg_info
writing glustercli.egg-info/PKG-INFO
writing dependency_links to glustercli.egg-info/dependency_links.txt

[ ... ]

Finished processing dependencies for glustercli===master
```

**With proposal**
```bash
$ python setup.py sdist bdist_wheel

[ ... ]

$ cd dist && tar -xzf glustercli-0.8.4+g78f1bc6.tar.gz && cd glustercli-0.8.4+g78f1bc6 && python setup.py install
running install
running bdist_egg
running egg_info
writing glustercli.egg-info/PKG-INFO
writing dependency_links to glustercli.egg-info/dependency_links.txt

[ ... ]

Finished processing dependencies for glustercli==0.8.4+g78f1bc6
```

Resolves #56 