### PR TITLE
Allow to setup package with older python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
-import os
-import re
+try:
+    # python >=3.8
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError:
+    # python <3.8
+    # importlib.metadata not available for python 3.7
+    from importlib_metadata import version, PackageNotFoundError
 from setuptools import setup
-from importlib.metadata import version, PackageNotFoundError
 
 try:
     __version__ = version('glustercli')


### PR DESCRIPTION
For example with Python 3.7 without this patch its failing with:

```
      File "/tmp/pip-req-build-mkwq4yyi/setup.py", line 4, in <module>
        from importlib.metadata import version, PackageNotFoundError
    ModuleNotFoundError: No module named 'importlib.metadata'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in
/tmp/pip-req-build-mkwq4yyi/
```

This also remove unused import `os` and `re`